### PR TITLE
Improve `npm run eject` description

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -82,7 +82,7 @@ module.exports = function(appPath, appName, verbose, originalDirectory) {
     console.log();
     console.log('  * npm start: Starts the development server.');
     console.log('  * npm run build: Bundles the app into static files for production.');
-    console.log('  * npm run eject: Removes this tool. If you do this, you can’t go back!');
+    console.log('  * npm run eject: Removes this tool and copies build dependencies, configs, and scripts into the app directory. If you do this, you can’t go back!');
     console.log();
     console.log('We suggest that you begin by typing:');
     console.log();


### PR DESCRIPTION
I feel as if the description for `npm run eject` is incredibly vague. `eject` does more than just removing the tool and that should be explained to the user.